### PR TITLE
Allow collection of artifacts, specifically:

### DIFF
--- a/src/DockerRunner.ts
+++ b/src/DockerRunner.ts
@@ -144,4 +144,8 @@ export default class DockerRunner implements Runner {
       this.containerName(instance) + "-tmp-container"
     ]);
   }
+
+  getRootDir() : string {
+    throw new Error("DockerRunner.getRootDir() is not implemented");
+  }
 }

--- a/src/Instance.ts
+++ b/src/Instance.ts
@@ -18,4 +18,5 @@ export default interface Instance {
   role: Role;
   id?: string;
   version?: VersionResponse;
+  dir?: string;
 }

--- a/src/LocalRunner.ts
+++ b/src/LocalRunner.ts
@@ -1,20 +1,32 @@
 "use strict";
 import path = require("path");
-import { promisify } from "util";
 import Instance from "./Instance";
 import Runner from "./Runner";
 import { createEndpoint, startInstance } from "./common";
 import tmp = require("tmp");
 import mkdirp = require("mkdirp-promise");
-import fs = require("fs");
 import rmRf = require("rmfr");
-const rename = promisify(fs.rename);
+import { SimpleOptions } from "tmp";
+
+const debugLog = (...logLine: any[]) => {
+  if (process.env.LOG_IMMEDIATE && process.env.LOG_IMMEDIATE == "1") {
+    const [fmt, ...args] = logLine;
+    console.log(new Date().toISOString() + " " + fmt, ...args);
+  }
+};
 
 export default class LocalRunner implements Runner {
   basePath: string;
-  rootDir: string;
-  constructor(basePath: string) {
-    this.rootDir = tmp.dirSync({ prefix: "arango-resilience" }).name;
+  rootDir?: string;
+  newDirOptions: SimpleOptions;
+
+  constructor(basePath: string, instancesDirectory?: string) {
+    this.newDirOptions = { prefix: "arango-resilience" };
+    if (instancesDirectory !== undefined) {
+      this.newDirOptions.dir = instancesDirectory;
+    }
+    // rootDir will be created when the first instance is started
+    this.rootDir = undefined;
     this.basePath = basePath;
   }
 
@@ -23,7 +35,9 @@ export default class LocalRunner implements Runner {
   }
 
   firstStart(instance: Instance): Promise<Instance> {
-    const dir = path.join(this.rootDir, instance.name);
+    this.assertRootDir();
+    const dir = path.join(this.getRootDir(), instance.name);
+    instance.dir = dir;
     const dataDir = path.join(dir, "data");
     const appsDir = path.join(dir, "apps");
     const logFile = path.join(dir, "arangod.log");
@@ -63,16 +77,50 @@ export default class LocalRunner implements Runner {
   }
 
   destroy(instance: Instance): Promise<void> {
-    return rmRf(path.join(this.rootDir, instance.name));
+    return rmRf(path.join(this.getRootDir(), instance.name));
   }
 
   cleanup(retainDir: boolean): Promise<void> {
+    const oldDirectory = this.rootDir;
+    this.rootDir = undefined;
+
     if (retainDir) {
-      const newDir = tmp.dirSync({ prefix: "arango-resilience-failure" }).name;
-      console.warn(`Test failed, moving files to ${newDir}`);
-      return rename(this.rootDir, newDir);
+      console.warn(`Test failed, won't remove directory ${oldDirectory}`);
+      return Promise.resolve();
+    } else if(oldDirectory !== undefined) {
+      // TODO remove the log message
+      debugLog(`Removing directory ${oldDirectory}`);
+      return rmRf(oldDirectory);
     } else {
-      return rmRf(this.rootDir);
+      console.warn(`There is no rootDir, `
+        + `did you call cleanup before starting an instance?`);
+      return Promise.resolve();
     }
+  }
+
+  getRootDir(): string {
+    this.assertRootDir();
+    // assertRootDir guarantees rootDir to be a string
+    return this.rootDir as string;
+  }
+
+  private createNewRootDir(): void {
+    if (this.rootDir !== undefined) {
+      console.error(`Creating a new root directory, but the old wasn't cleaned `
+        + `up! Old directory was: ${this.rootDir}`);
+    }
+
+    this.rootDir = tmp.dirSync(this.newDirOptions).name;
+
+    debugLog(`Created new root directory ${this.rootDir}`);
+  }
+
+  // Create root directory if necessary.
+  private assertRootDir(): void {
+    if (this.rootDir !== undefined) {
+      return;
+    }
+
+    this.createNewRootDir();
   }
 }

--- a/src/Runner.ts
+++ b/src/Runner.ts
@@ -7,4 +7,5 @@ export default interface Runner {
   restart(instance: Instance): Promise<Instance>;
   destroy(instance: Instance): Promise<void>;
   cleanup(retainDir: boolean): Promise<void>;
+  getRootDir(): string;
 }


### PR DESCRIPTION
- Create a new instances directory after each cleanup
- Write an optional NOTES file into the instances directory
- Make the parent directory for instances directories configurable
- Move core files in the corresponding instance directory, if existent