### PR TITLE
Rename _iresearch_analyzers to _analyzers for 3.5

### DIFF
--- a/src/InstanceManager.ts
+++ b/src/InstanceManager.ts
@@ -640,7 +640,7 @@ export default class InstanceManager {
       "_aqlfunctions",
       "_frontend",
       "_graphs",
-      "_iresearch_analyzers",
+      "_analyzers",
       "_jobs",
       "_modules",
       "_queues",
@@ -652,9 +652,15 @@ export default class InstanceManager {
     ]);
     const version = this.getArangoVersion();
 
+    // _analyzers are available since 3.5
     if (version.major <= 3 && version.minor < 4) {
-      // _iresearch_analyzers is available only since 3.4
-      systemCollections.delete('_iresearch_analyzers');
+      systemCollections.delete('_analyzers');
+    }
+    // except in 3.4 (and only in 3.4) they were called
+    // _iresearch_analyzers
+    if (version.major <= 3 && version.minor == 4) {
+      systemCollections.delete('_analyzers');
+      systemCollections.add('_iresearch_analyzers');
     }
 
     const allInSync = function (

--- a/src/InstanceManager.ts
+++ b/src/InstanceManager.ts
@@ -658,7 +658,7 @@ export default class InstanceManager {
     }
     // except in 3.4 (and only in 3.4) they were called
     // _iresearch_analyzers
-    if (version.major <= 3 && version.minor == 4) {
+    if (version.major == 3 && version.minor == 4) {
       systemCollections.delete('_analyzers');
       systemCollections.add('_iresearch_analyzers');
     }


### PR DESCRIPTION
In ArangoDB 3.5 and upwards `_iresearch_analyzers` is called `_analyzers`.