### PR TITLE
bug-fix/added-fishbowl-collection

### DIFF
--- a/src/InstanceManager.ts
+++ b/src/InstanceManager.ts
@@ -638,6 +638,7 @@ export default class InstanceManager {
       "_appbundles",
       "_apps",
       "_aqlfunctions",
+      "_fishbowl",
       "_frontend",
       "_graphs",
       "_analyzers",


### PR DESCRIPTION
Added fishbowl collection.

That collection was not part of `systemCollections - new Set<string>`, what is wrong.
Not failed before because of old lazy system collection behaviour. 